### PR TITLE
[SB][134083245] `relocate-keys` should not leave orig key with nil val

### DIFF
--- a/src/rp/util/map.clj
+++ b/src/rp/util/map.clj
@@ -49,6 +49,6 @@
   "Returns a map where the value in a nested associative structure is relocated
    from the path specified by key sequence ks1 to the path of key sequence ks2."
   [m ks1 ks2]
-  (if-let [val-to-move (get-in m ks1)]
-    (assoc-in (dissoc-in m ks1) ks2 val-to-move)
-    m))
+  (let [val-to-move (get-in m ks1)]
+    (cond-> (dissoc-in m ks1)
+      val-to-move (assoc-in ks2 val-to-move))))

--- a/test/rp/util/map_test.clj
+++ b/test/rp/util/map_test.clj
@@ -82,4 +82,10 @@
                               :parents {:homer {:abe :male
                                                 :mona :female}}}}]
     (is (= relocated
-           (relocate-keys m [:homer-parents] [:simpsons :parents :homer])))))
+           (relocate-keys m [:homer-parents] [:simpsons :parents :homer]))))
+
+  (is (= {:range {:low 3}}
+         (relocate-keys {:range {:low 3 :high nil}}
+                        [:range :high]
+                        [:some :where :else]))
+      "Original keys should always be removed, even when present with a nil value."))


### PR DESCRIPTION
Over in listing-saal I noticed this behavior:

```clojure
(-> {:bathroom-range {:low 2 :high nil}}
    (util-map/relocate-keys [:bathroom-range :low] [:intermediate-qdsl :where :gteq :fullbaths])
    (util-map/relocate-keys [:bathroom-range :high] [:intermediate-qdsl :where :lteq :fullbaths]))

{:bathroom-range {:high nil}, :intermediate-qdsl {:where {:gteq {:fullbaths 2}}}}
```

It seems to me that we shouldn't leave the key around when it has a `nil` value.
This change "fixes" that issue.

However I'm not sure this is a good idea. One might actually want to relocate a key with a `nil` value in some cases. Perhaps an option could be added that determines whether keys with `nil` values should be moved or simply discarded. Although in that case, what should be the default behavior?