### PR TITLE
[SB][135632767] Add bats-and-carets->maps

### DIFF
--- a/src/rp/util/seq.clj
+++ b/src/rp/util/seq.clj
@@ -1,0 +1,6 @@
+(ns rp.util.seq)
+
+(defn tuples->maps
+  "Return a vector of maps where each map has the specified keys with values from each tuple."
+  [ks tuples]
+  (mapv #(zipmap ks %) tuples))

--- a/src/rp/util/string.clj
+++ b/src/rp/util/string.clj
@@ -1,6 +1,7 @@
 (ns rp.util.string
   (:require [clojure.tools.reader.edn :as edn]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [rp.util.seq :as util-seq]))
 
 (def regexes
   {:long (re-pattern "([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?")
@@ -74,3 +75,7 @@
   [s]
   (when (non-blank-string s)
     (mapv split-on-caret (split-on-bat s))))
+
+(defn bats-and-carets->maps
+  [ks s]
+  (util-seq/tuples->maps ks (split-on-bats-and-carets s)))

--- a/test/rp/util/seq_test.clj
+++ b/test/rp/util/seq_test.clj
@@ -1,0 +1,11 @@
+(ns rp.util.seq-test
+  (:require [clojure.test :refer :all]
+            [rp.util.seq :refer :all]))
+
+(deftest test-tuples->maps
+  (let [ks [:x :y]]
+    (are [x result] (= result (tuples->maps ks x))
+      [[1 2] [3 4]] [{:x 1 :y 2}
+                     {:x 3 :y 4}]
+      [[1] [2 3 4]] [{:x 1}
+                     {:x 2 :y 3}])))

--- a/test/rp/util/string_test.clj
+++ b/test/rp/util/string_test.clj
@@ -72,3 +72,18 @@
     "foobar^+^barfoo" [["foobar"] ["barfoo"]]
     "alpha^1^+^beta^2" [["alpha" "1"] ["beta" "2"]]
     "^^+^bar^^+^" [[] ["bar"]]))
+
+(deftest test-bats-and-carets->maps
+  (let [ks [:x :y]]
+    (are [x result] (= result (bats-and-carets->maps ks x))
+      nil []
+      "" []
+      ;; A value for each key (normal case)
+      "a^b^+^c^d" [{:x "a" :y "b"}
+                   {:x "c" :y "d"}]
+      ;; Extra values are ignored
+      "a^b^+^c^d^e" [{:x "a" :y "b"}
+                     {:x "c" :y "d"}]
+      ;; Keys without a value are discarded
+      "a^b^+^c" [{:x "a" :y "b"}
+                 {:x "c"}])))


### PR DESCRIPTION
This PR is mainly about adding `bats-and-carets->maps` which can be used to parse a batty Endeca string into a vector of maps with the given keys.

Example usage:
```clojure
(bats-and-carets->maps [:key :order] 
                       "isapartment^desc^+^is27705^desc^+^sortorder^asc^+^geocode(36.02006,-78.957631)^asc")
=> [{:key "isapartment", :order "desc"}
    {:key "is27705", :order "desc"}
    {:key "sortorder", :order "asc"}
    {:key "geocode(36.02006,-78.957631)", :order "asc"}]
```