### PR TITLE
[SB][135632085] Change split behavior

### DIFF
--- a/src/rp/util/string.clj
+++ b/src/rp/util/string.clj
@@ -42,8 +42,9 @@
 
 (defn- split-on-re
   [re s]
-  (when (non-blank-string s)
-    (mapv str/trim (str/split s re))))
+  (if (non-blank-string s)
+    (mapv str/trim (str/split s re))
+    []))
 
 (def parse-double* (make-parser (:double regexes)))
 
@@ -72,8 +73,7 @@
 
 (defn split-on-bats-and-carets
   [s]
-  (when (non-blank-string s)
-    (mapv split-on-caret (split-on-bat s))))
+  (mapv split-on-caret (split-on-bat s)))
 
 (defn carets->map
   [ks s]

--- a/test/rp/util/string_test.clj
+++ b/test/rp/util/string_test.clj
@@ -54,20 +54,21 @@
 
 (deftest test-split-on-re
   (are [x re result] (= result (#'rp.util.string/split-on-re re x))
-    nil (:caret regexes) nil
-    13 (:comma regexes) nil
-    "" (:caret regexes) nil
+    nil (:caret regexes) []
+    13 (:comma regexes) []
+    "" (:caret regexes) []
     "," (:comma regexes) []
     "^" (:caret regexes) []
     "foobar" (:caret regexes) ["foobar"]
     "foo^bar" (:caret regexes) ["foo" "bar"]
     "^foo^bar^" (:caret regexes) ["" "foo" "bar"]
+    " ^ foo ^ bar ^" (:caret regexes) ["" "foo" "bar"]
     "fred,bill,bob" (:comma regexes) ["fred" "bill" "bob"]))
 
 (deftest test-split-on-bats-and-carets
   (are [x result] (= result (split-on-bats-and-carets x))
-    nil nil
-    "" nil
+    nil []
+    "" []
     "foobar" [["foobar"]]
     "foobar^+^barfoo" [["foobar"] ["barfoo"]]
     "alpha^1^+^beta^2" [["alpha" "1"] ["beta" "2"]]


### PR DESCRIPTION
This is one of two proposed changes that I'd like to make so that I can remove the `non-blank-string` coercions from https://github.com/rentpath/rp-endeca-clj/pull/64.
This proposed change is the more sweeping of the two. The main change is the normalizing of empty strings to nils (change #2 below), but as I was looking at the split functions more closely I found their current `nil` returning behavior a little odd so I added change #1 as well.
I could be talked out of change #1 though.
Or see the [other proposal which is in another PR](https://github.com/rentpath/rp-util-clj/pull/13).

This makes two changes to split behavior:
1. Always return a vector, even when passed nil or an empty string.
2. In addition to trimming whitespace from each split item, normalize
   empty strings to nil.

Note that these changes technically break backward compatibility. so we
should do a major version bump post-merge. However so far there are very
few users of this library yet, so I don't anticipate that any users will
need to change when they update their dependency on this lib.

Old behavior:
```clojure
(split-on-caret nil) => nil
(split-on-caret "") => nil
(split-on-caret "^2") => ["" "2"]
(split-on-bats-and-carets nil) => nil
(split-on-bats-and-carets "") => nil
(split-on-bats-and-carets "a^b^+^^d") => [["a" "b"] ["" "d"]]
```

New behavior:
```clojure
(split-on-caret nil) => []
(split-on-caret "") => []
(split-on-caret "^2") => [nil "2"]
(split-on-bats-and-carets nil) => []
(split-on-bats-and-carets "") => []
(split-on-bats-and-carets "a^b^+^c^d") => [["a" "b"] [nil "d"]]
```

Same before and after:
```clojure
(split-on-caret "^") => []
(split-on-caret "1^2") => ["1" "2"]
(split-on-caret " 1 ^ 2 ") => ["1" "2"]
(split-on-bats-and-carets "a^b^+^c^d") => [["a" "b"] ["c" "d"]]
```