### PR TITLE
[SB][135632085] Change carets->map so it discards blank values

### DIFF
--- a/src/rp/util/map.clj
+++ b/src/rp/util/map.clj
@@ -52,3 +52,10 @@
   (let [val-to-move (get-in m ks1)]
     (cond-> (dissoc-in m ks1)
       val-to-move (assoc-in ks2 val-to-move))))
+
+(defn remove-nils
+  [m]
+  (reduce-kv (fn [acc k v]
+               (if v (assoc acc k v) acc))
+             {}
+             m))

--- a/src/rp/util/string.clj
+++ b/src/rp/util/string.clj
@@ -1,6 +1,7 @@
 (ns rp.util.string
   (:require [clojure.tools.reader.edn :as edn]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [rp.util.map :as util-map]))
 
 (def regexes
   {:long (re-pattern "([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?")
@@ -77,7 +78,11 @@
 
 (defn carets->map
   [ks s]
-  (zipmap ks (split-on-caret s)))
+  (->> s
+       split-on-caret
+       (map non-blank-string)
+       (zipmap ks)
+       util-map/remove-nils))
 
 (defn bats-and-carets->maps
   [ks s]

--- a/test/rp/util/map_test.clj
+++ b/test/rp/util/map_test.clj
@@ -89,3 +89,7 @@
                         [:range :high]
                         [:some :where :else]))
       "Original keys should always be removed, even when present with a nil value."))
+
+(deftest test-remove-nils
+  (is (= {:a 1 :c ""}
+         (remove-nils {:a 1 :b nil :c ""}))))

--- a/test/rp/util/string_test.clj
+++ b/test/rp/util/string_test.clj
@@ -84,7 +84,9 @@
       ;; Extra values are ignored
       "a^b^c" {:x "a" :y "b"}
       ;; Keys without a value are discarded
-      "a" {:x "a"})))
+      "a" {:x "a"}
+      "^b" {:y "b"}
+      " ^ b" {:y "b"})))
 
 (deftest test-bats-and-carets->maps
   (let [ks [:x :y]]
@@ -99,4 +101,6 @@
                      {:x "c" :y "d"}]
       ;; Keys without a value are discarded
       "a^b^+^c" [{:x "a" :y "b"}
-                 {:x "c"}])))
+                 {:x "c"}]
+      "^b^+^^d" [{:y "b"}
+                 {:y "d"}])))


### PR DESCRIPTION
This is one of two proposed changes that I'd like to make so that I can remove the `non-blank-string` coercions from https://github.com/rentpath/rp-endeca-clj/pull/64.
This proposed change is the more conservative of the two since it leaves the split functions alone.