### PR TITLE
[SB][135632085] Change carets->map so it ensures all keys present

### DIFF
--- a/src/rp/util/map.clj
+++ b/src/rp/util/map.clj
@@ -52,3 +52,14 @@
   (let [val-to-move (get-in m ks1)]
     (cond-> (dissoc-in m ks1)
       val-to-move (assoc-in ks2 val-to-move))))
+
+(defn ensure-keys
+  "Ensures that the given map has all of the specified keys.
+   Any missing keys are associated with a `nil` value."
+  [ks m]
+  (reduce (fn [acc k]
+            (if (contains? acc k)
+              acc
+              (assoc acc k nil)))
+          m
+          ks))

--- a/src/rp/util/string.clj
+++ b/src/rp/util/string.clj
@@ -1,6 +1,7 @@
 (ns rp.util.string
   (:require [clojure.tools.reader.edn :as edn]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [rp.util.map :as util-map]))
 
 (def regexes
   {:long (re-pattern "([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?")
@@ -77,7 +78,11 @@
 
 (defn carets->map
   [ks s]
-  (zipmap ks (split-on-caret s)))
+  (->> s
+       split-on-caret
+       (map non-blank-string)
+       (zipmap ks)
+       (util-map/ensure-keys ks)))
 
 (defn bats-and-carets->maps
   [ks s]

--- a/test/rp/util/map_test.clj
+++ b/test/rp/util/map_test.clj
@@ -89,3 +89,7 @@
                         [:range :high]
                         [:some :where :else]))
       "Original keys should always be removed, even when present with a nil value."))
+
+(deftest test-ensure-keys
+  (is (= {:a nil :b "foo" :c nil :d "bar"}
+         (ensure-keys [:a :b :c] {:b "foo" :d "bar"}))))

--- a/test/rp/util/string_test.clj
+++ b/test/rp/util/string_test.clj
@@ -76,14 +76,16 @@
 (deftest test-carets->map
   (let [ks [:x :y]]
     (are [x result] (= result (carets->map ks x))
-      nil {}
-      "" {}
       ;; A value for each key (normal case)
       "a^b" {:x "a" :y "b"}
       ;; Extra values are ignored
       "a^b^c" {:x "a" :y "b"}
-      ;; Keys without a value are discarded
-      "a" {:x "a"})))
+      ;; Keys without a value default to nil
+      nil {:x nil :y nil}
+      "" {:x nil :y nil}
+      "a" {:x "a" :y nil}
+      "^b" {:x nil :y "b"}
+      " ^ b" {:x nil :y "b"})))
 
 (deftest test-bats-and-carets->maps
   (let [ks [:x :y]]
@@ -96,6 +98,8 @@
       ;; Extra values are ignored
       "a^b^+^c^d^e" [{:x "a" :y "b"}
                      {:x "c" :y "d"}]
-      ;; Keys without a value are discarded
+      ;; Keys without a value default to nil
       "a^b^+^c" [{:x "a" :y "b"}
-                 {:x "c"}])))
+                 {:x "c" :y nil}]
+      "^b^+^^d" [{:x nil :y "b"}
+                 {:x nil :y "d"}])))


### PR DESCRIPTION
This is yet a 3rd proposal for dealing with missing values in a caret-delimited value.
With this approach, all of the specified keys are guaranteed to be present in the result.

For example, let's consider parsing `officehours` with a raw value like `"0^^^Call 555-1212 for emergencies^+^1^01:00 PM^05:00 PM^^+^2^09:00 AM^06:00 PM^^+^3^09:00 AM^06:00 PM^^+^4^09:00 AM^06:00 PM^^+^5^09:00 AM^06:00 PM^^+^6^09:00 AM^06:00 PM^^+^7^10:00 AM^05:00 PM^"`.
With the code as it currently is in https://github.com/rentpath/rp-endeca-clj/pull/64, the coerced value would be:
```clojure
[{:day :other :open-time nil :close-time nil :status "Call 555-1212 for emergencies"}
 {:day :sunday :open-time "01:00 PM" :close-time "05:00 PM"}
 {:day :monday :open-time "09:00 AM" :close-time "06:00 PM"}
 {:day :tuesday :open-time "09:00 AM" :close-time "06:00 PM"}
 {:day :wednesday :open-time "09:00 AM" :close-time "06:00 PM"}
 {:day :thursday :open-time "09:00 AM" :close-time "06:00 PM"}
 {:day :friday :open-time "09:00 AM" :close-time "06:00 PM"}
 {:day :saturday :open-time "10:00 AM" :close-time "05:00 PM"}]
```
Note that I had to explicitly coerce empty strings to nil for the times (since they occur in the middle) and the `:status` key is missing from all but the first map (due to the split behavior).

With the changes in this PR, I could skip explicitly coercing empty strings to nil and would get a result like this (with all keys present in each map):
```clojure
[{:day :other :open-time nil :close-time nil :status "Call 555-1212 for emergencies"}
 {:day :sunday :open-time "01:00 PM" :close-time "05:00 PM" :status nil}
 {:day :monday :open-time "09:00 AM" :close-time "06:00 PM" :status nil}
 {:day :tuesday :open-time "09:00 AM" :close-time "06:00 PM" :status nil}
 {:day :wednesday :open-time "09:00 AM" :close-time "06:00 PM" :status nil}
 {:day :thursday :open-time "09:00 AM" :close-time "06:00 PM" :status nil}
 {:day :friday :open-time "09:00 AM" :close-time "06:00 PM" :status nil}
 {:day :saturday :open-time "10:00 AM" :close-time "05:00 PM" :status nil}]
```

I think I prefer this approach. All 3 approaches free us from having to coerce missing values to nil just because they happen to be in the middle of a delimited string. However this is the only one that ensures that all keys are present.
I like that both approach 2 and 3 are consistent about what keys are present. So one of them gets my vote.
With approach 1, some keys may be present with nil values and other keys could simply be missing, which seems inconsistent.  However if one or both of the split changes from approach 1 are deemed good ideas, they could be borrowed and applied to approach 2 or 3 as well.