### PR TITLE
version bump org.clojure/tools.reader dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,6 @@
                                      :password [:gpg :env/CLOJARS_PASSWORD]
                                      :sign-releases false}]]
   :global-vars {*warn-on-reflection* true}
-  :dependencies [[org.clojure/tools.reader "1.0.0-beta3"]
+  :dependencies [[org.clojure/tools.reader "1.0.5"]
                  [org.clojure/test.check "0.9.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0-alpha17"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0-alpha19"]]}})


### PR DESCRIPTION
bumping `tools.reader` or should that dependency be declared `:provided`?