### PR TITLE
Extraction and generalization of rp.csi.util.retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rentpath/rp-util-clj "1.0.14-SNAPSHOT"
+(defproject com.rentpath/rp-util-clj "1.0.13-SNAPSHOT"
   :description "Common utilities"
   :url "https://github.com/rentpath/rp-util-clj"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rentpath/rp-util-clj "1.0.13-SNAPSHOT"
+(defproject com.rentpath/rp-util-clj "1.0.14-SNAPSHOT"
   :description "Common utilities"
   :url "https://github.com/rentpath/rp-util-clj"
   :license {:name "Eclipse Public License"

--- a/src/rp/util/retry.clj
+++ b/src/rp/util/retry.clj
@@ -1,0 +1,47 @@
+(ns rp.util.retry)
+
+(defn with-retries
+  "Call the provided function, retrying it up to max-attempts
+  if any of the specified exceptions are thrown.
+  Options:
+  max-attempts - The maximum number of times to call the function. If value is -1, retry infinitely.
+  exceptions - a sequence of Exception classes to catch. Default to java.lang.Exception
+  delay - The number of milliseconds to wait between attempts, multipled by the attempt count
+  max-delay - The longest number of milliseconds to wait between attempts regardless of attempt number.
+              Used in conjunction with infinite max-attempts.
+  predicate - An optional function that indicates whether to retry. Takes one Exception argument
+  error-fn - A function invoked with each exception encountered
+  failure-fn - A function invoked when the max attempts or max delay have been reached"
+  [f & {:keys [max-attempts attempt delay max-delay exceptions predicate error-fn failure-fn]
+        :or {max-attempts 5
+             attempt 1
+             delay 1000
+             exceptions [Exception]
+             predicate boolean
+             error-fn identity
+             failure-fn identity}}]
+  (let [max-delay (or max-delay
+                      (Math/abs (* delay max-attempts)))
+        infinite? (< max-attempts 0)]
+    (loop [attempt 1]
+      (let [sleep-time (min max-delay (* delay attempt))
+            result (try
+                     (f)
+                     (catch Exception e
+                       (error-fn e)
+                       (let [retry? (and (or (> max-attempts attempt)
+                                             infinite?)
+                                         (some #(instance? % e) exceptions)
+                                         (predicate e))]
+                         (when (or (not retry?)
+                                   (and infinite?
+                                        (>= sleep-time max-delay)))
+                           (failure-fn e))
+                         (if retry?
+                           ::retry
+                           (throw e)))))]
+        (if (= result ::retry)
+          (do
+            (Thread/sleep sleep-time)
+            (recur (inc attempt)))
+          result)))))

--- a/test/rp/util/retry_test.clj
+++ b/test/rp/util/retry_test.clj
@@ -1,0 +1,74 @@
+(ns rp.util.retry-test
+  (:require [clojure.test :refer :all]
+            [rp.util.retry :refer :all]))
+
+(defn build-collector []
+  (atom {:counter      0
+         :periods      []
+         :last-attempt (System/currentTimeMillis)}))
+
+(defn build-testfn [collector]
+  (fn []
+    (swap! collector
+           (fn [{:keys [last-attempt counter] :as c}]
+             (let [now (System/currentTimeMillis)]
+               (-> (if (> counter 0)
+                     (update c :periods conj (- now last-attempt))
+                     c)
+                   (update :counter inc)
+                   (assoc :last-attempt now)))))
+    (throw (Exception. "Generic Exception"))))
+
+(defn test-collector [collector & {:keys [expected-attempts expected-delay timing-error-allowance]
+                                   :or   {expected-attempts      5
+                                          expected-delay         1000
+                                          timing-error-allowance 20}}]
+  (let [{:keys [periods counter]} @collector]
+    (is (= expected-attempts counter))
+    (doseq [i (range (dec expected-attempts))]
+      (is (< (Math/abs (- (nth periods i) (* (inc i) expected-delay))) timing-error-allowance)))))
+
+(deftest test-defaults
+  (let [collector (build-collector)
+        f (build-testfn collector)]
+    (try (with-retries f)
+         (catch Exception _))
+    (test-collector collector)))
+
+(deftest test-max-attempts
+  (let [collector (build-collector)
+        f (build-testfn collector)]
+    (try (with-retries f :max-attempts 3)
+         (catch Exception _))
+    (test-collector collector :expected-attempts 3)))
+
+(deftest test-delay
+  (let [collector (build-collector)
+        f (build-testfn collector)]
+    (try (with-retries f :delay 500)
+         (catch Exception _))
+    (test-collector collector :expected-delay 500)))
+
+(deftest test-error-fn
+  (let [collector (build-collector)
+        f (build-testfn collector)
+        error-fn-call-count (atom 0)
+        error-fn (fn [^Exception e]
+                  (swap! error-fn-call-count inc)
+                  (is (= (.getMessage e) "Generic Exception"))
+                  (is (instance? Exception e)))]
+    (try (with-retries f :error-fn error-fn)
+         (catch Exception _))
+    (is (= 5 @error-fn-call-count))))
+
+(deftest test-failure-fn
+  (let [collector (build-collector)
+        f (build-testfn collector)
+        failure-fn-call-count (atom 0)
+        failure-fn (fn [^Exception e]
+                   (swap! failure-fn-call-count inc)
+                   (is (= (.getMessage e) "Generic Exception"))
+                   (is (instance? Exception e)))]
+    (try (with-retries f :failure-fn failure-fn)
+         (catch Exception _))
+    (is (= 1 @failure-fn-call-count))))


### PR DESCRIPTION
This extracts the `with-retries` function from the [csi-service](https://github.com/rentpath/csi-service) application [rp.csi.util.retry](https://github.com/rentpath/csi-service/blob/master/src/rp/csi/util/retry.clj) namespace into this shared library for usage elsewhere in addition to that application. A forthcoming PR thereto will eliminate the existing app-specific code. Undertaken in order to implement retrying cache fetches for the [seo-index-service](https://github.com/rentpath/seo-index-service) in an attempt to avoid the intermittent failure thereof per the card.

Card: [Resolve occasional 500 response status](https://rentpath.leankit.com/card/646776790)